### PR TITLE
fix: bump resource/block kinds to match kapeta versions

### DIFF
--- a/services/todo-ui/kapeta.yml
+++ b/services/todo-ui/kapeta.yml
@@ -1,4 +1,4 @@
-kind: kapeta/block-type-frontend:0.0.1
+kind: kapeta/block-type-frontend:0.0.2
 metadata:
   name: kapeta/nodejs-sample-todo-ui
   title: Todo UI
@@ -55,13 +55,13 @@ spec:
         	id: string
         }
   providers:
-    - kind: kapeta/resource-type-web-page:0.0.1
+    - kind: kapeta/resource-type-web-page:0.0.3
       metadata:
         name: todo
       spec:
         path: /
   consumers:
-    - kind: kapeta/resource-type-rest-client:0.0.1
+    - kind: kapeta/resource-type-rest-client:0.0.2
       metadata:
         name: tasks
       spec:

--- a/services/todo/kapeta.yml
+++ b/services/todo/kapeta.yml
@@ -63,7 +63,7 @@ spec:
         	email: string
         }
   consumers:
-    - kind: kapeta/resource-type-rest-client:0.0.1
+    - kind: kapeta/resource-type-rest-client:0.0.2
       metadata:
         name: users
       spec:
@@ -84,11 +84,11 @@ spec:
             //Get users by id
             @GET("/users/{id}")
             getUserById(@Path id:string):User
-    - kind: kapeta/resource-type-mongodb:0.0.1
+    - kind: kapeta/resource-type-mongodb:0.0.2
       metadata:
         name: tasks
   providers:
-    - kind: kapeta/resource-type-rest-api:0.0.1
+    - kind: kapeta/resource-type-rest-api:0.0.2
       metadata:
         name: tasks
       spec:

--- a/services/ui-gateway/kapeta.yml
+++ b/services/ui-gateway/kapeta.yml
@@ -1,4 +1,4 @@
-kind: kapeta/block-type-frontend:0.0.1
+kind: kapeta/block-type-frontend:0.0.2
 metadata:
   name: kapeta/sample-nodejs-ui-gateway
   title: Todo App
@@ -6,18 +6,18 @@ spec:
   target:
     kind: kapeta/language-target-react-ts:0.0.1
   providers:
-    - kind: kapeta/resource-type-web-page:0.0.1
+    - kind: kapeta/resource-type-web-page:0.0.3
       metadata:
         name: web
       spec:
         path: /
   consumers:
-    - kind: kapeta/resource-type-web-fragment:0.0.1
+    - kind: kapeta/resource-type-web-fragment:0.0.3
       metadata:
         name: todo
       spec:
         path: /todo
-    - kind: kapeta/resource-type-web-fragment:0.0.1
+    - kind: kapeta/resource-type-web-fragment:0.0.3
       metadata:
         name: Users
       spec:

--- a/services/users-ui/kapeta.yml
+++ b/services/users-ui/kapeta.yml
@@ -1,4 +1,4 @@
-kind: kapeta/block-type-frontend:0.0.1
+kind: kapeta/block-type-frontend:0.0.2
 metadata:
   name: kapeta/nodejs-sample-user-ui
   title: User UI
@@ -91,13 +91,13 @@ spec:
         	email: string
         }
   providers:
-    - kind: kapeta/resource-type-web-page:0.0.1
+    - kind: kapeta/resource-type-web-page:0.0.3
       metadata:
         name: Users
       spec:
         path: /
   consumers:
-    - kind: kapeta/resource-type-rest-client:0.0.1
+    - kind: kapeta/resource-type-rest-client:0.0.2
       metadata:
         name: users
       spec:

--- a/services/users/kapeta.yml
+++ b/services/users/kapeta.yml
@@ -121,11 +121,11 @@ spec:
         	done: boolean
         }
   consumers:
-    - kind: kapeta/resource-type-postgresql:0.0.1
+    - kind: kapeta/resource-type-postgresql:0.0.2
       metadata:
         name: users
   providers:
-    - kind: kapeta/resource-type-rest-api:0.0.1
+    - kind: kapeta/resource-type-rest-api:0.0.2
       metadata:
         name: users
       spec:


### PR DESCRIPTION
The 0.0.1 versions of many resources are not available. This seems to be at least mostly working.

<img width="1296" alt="Screenshot 2023-04-03 at 18 07 06" src="https://user-images.githubusercontent.com/296057/229565985-e86ed466-068b-4ab9-be9e-729dd0b157a9.png">
