### PR TITLE
fix: Handle multiple gosmtpd containers

### DIFF
--- a/open-gosmtpd-inbox.sh
+++ b/open-gosmtpd-inbox.sh
@@ -1,13 +1,8 @@
 #!/bin/bash
 
-# Function to get the port of the most recently started container
-get_port() {
-  docker ps --format '{{.CreatedAt}} {{.ID}} {{.Image}} {{.Ports}}' | grep gosmtpd | sort -r | head -n 1 | awk '{ for(i=4; i<=NF; i++) print $i }' | grep '8000/tcp' | awk -F':' '{print $2}' | awk -F'->' '{print $1}'
-}
-
 # Function to open URL on Linux
 open_linux() {
-  PORT=$(get_port)
+  PORT=$(docker ps --format '{{.CreatedAt}} {{.ID}} {{.Image}} {{.Ports}}' | grep gosmtpd | sort -r | head -n 1 | awk '{ for(i=4; i<=NF; i++) print $i }' | grep '8000/tcp' | awk -F':' '{print $2}' | awk -F'->' '{print $1}')
   if [ ! -z "$PORT" ]; then
     xdg-open "http://localhost:$PORT/inbox"
   fi
@@ -15,7 +10,7 @@ open_linux() {
 
 # Function to open URL on macOS
 open_mac() {
-  PORT=$(get_port)
+  PORT=$(docker ps --format '{{.CreatedAt}} {{.ID}} {{.Image}} {{.Ports}}' | grep gosmtpd | sort -r | head -n 1 | awk '{ for(i=4; i<=NF; i++) print $i }' | grep '8000/tcp' | awk -F':' '{print $2}' | awk -F'->' '{print $1}')
   if [ ! -z "$PORT" ]; then
     open "http://localhost:$PORT/inbox"
   fi
@@ -23,7 +18,7 @@ open_mac() {
 
 # Function to open URL on Windows
 open_windows() {
-  PORT=$(get_port)
+  PORT=$(docker ps --format "{{.CreatedAt}} {{.ID}} {{.Image}} {{.Ports}}" | findstr "gosmtpd" | sort /R | findstr /v "sort" | head -n 1 | awk "{ for(i=4; i<=NF; i++) print $i }" | findstr "8000/tcp" | awk -F':' "{print $2}" | awk -F'->' "{print $1}")
   if [ ! -z "$PORT" ]; then
     start "http://localhost:$PORT/inbox"
   fi


### PR DESCRIPTION
Improvement to the "open gosmtpd inbox"-script.

There could be multiple containers running and the script got the ports for all. This PR changes the script to only open the inbox for the last created container.