### PR TITLE
build: use ESM w/ tree shaking

### DIFF
--- a/services/todo-ui/webpack.development.config.js
+++ b/services/todo-ui/webpack.development.config.js
@@ -78,7 +78,6 @@ const config = {
                     ],
                     plugins: [
                         ...(devMode ? ["react-refresh/babel"] : []),
-                        "@babel/plugin-transform-modules-commonjs",
                         ["@babel/plugin-proposal-decorators", { legacy: true }],
                         [
                             "@babel/plugin-proposal-private-methods",
@@ -114,7 +113,7 @@ const config = {
         ],
     },
     resolve: {
-        mainFields: ["main"],
+        mainFields: ["module", "main"],
         extensions: [
             ".js",
             ".jsx",

--- a/services/ui-gateway/webpack.development.config.js
+++ b/services/ui-gateway/webpack.development.config.js
@@ -78,7 +78,6 @@ const config = {
                     ],
                     plugins: [
                         ...(devMode ? ["react-refresh/babel"] : []),
-                        "@babel/plugin-transform-modules-commonjs",
                         ["@babel/plugin-proposal-decorators", { legacy: true }],
                         [
                             "@babel/plugin-proposal-private-methods",
@@ -114,7 +113,7 @@ const config = {
         ],
     },
     resolve: {
-        mainFields: ["main"],
+        mainFields: ["module", "main"],
         extensions: [
             ".js",
             ".jsx",

--- a/services/users-ui/webpack.development.config.js
+++ b/services/users-ui/webpack.development.config.js
@@ -78,7 +78,6 @@ const config = {
                     ],
                     plugins: [
                         ...(devMode ? ["react-refresh/babel"] : []),
-                        "@babel/plugin-transform-modules-commonjs",
                         ["@babel/plugin-proposal-decorators", { legacy: true }],
                         [
                             "@babel/plugin-proposal-private-methods",
@@ -114,7 +113,7 @@ const config = {
         ],
     },
     resolve: {
-        mainFields: ["main"],
+        mainFields: ["module", "main"],
         extensions: [
             ".js",
             ".jsx",


### PR DESCRIPTION
This includes two important changes;
- Don't force commonjs w/ `@babel/plugin-transform-modules-commonjs`
- Load `module` fields from `package.json` when possible, instead of always `main`.

The primary benefit is not loading most of MUI.

Results:
| fragment | before | after |
|--------|--------|--------|
| todo-ui | 1.47MB | 402KB |
| users-ui | 1.38MB | 356KB |
| ui-gateway | 1.44MB | 418KB | 